### PR TITLE
Add a default settings global page

### DIFF
--- a/block_course_contents.php
+++ b/block_course_contents.php
@@ -46,7 +46,6 @@ class block_course_contents extends block_base {
         if (!empty($this->config->blocktitle)) {
             $this->title = $this->config->blocktitle;
         } else {
-            $this->title = get_string('config_blocktitle_default', 'block_course_contents');
             $this->title = get_config('course_contents', 'blocktitle_default');
         }
     }

--- a/block_course_contents.php
+++ b/block_course_contents.php
@@ -47,6 +47,7 @@ class block_course_contents extends block_base {
             $this->title = $this->config->blocktitle;
         } else {
             $this->title = get_string('config_blocktitle_default', 'block_course_contents');
+            $this->title = get_config('course_contents', 'blocktitle_default');
         }
     }
 
@@ -124,7 +125,17 @@ class block_course_contents extends block_base {
                 $text .= html_writer::start_tag('li', array('class' => 'section-item r'.$odd));
             }
 
-            if (empty($this->config) or !isset($this->config->enumerate) or is_null($this->config->enumerate) or !empty($this->config->enumerate)) {
+            if (
+                (
+                    (
+                        empty($this->config)
+                        or !isset($this->config->enumerate)
+                        or is_null($this->config->enumerate)
+                    )
+                    and get_config('course_contents', 'enumerate_default')
+                )
+                or !empty($this->config->enumerate)
+            ) {
                 $title = html_writer::tag('span', $i.' ', array('class' => 'section-number')).
                     html_writer::tag('span', $title, array('class' => 'section-title'));
             } else {
@@ -185,5 +196,9 @@ class block_course_contents extends block_base {
             }
         }
         return $t;
+    }
+
+    function has_config() {
+        return true;
     }
 }

--- a/lang/en/block_course_contents.php
+++ b/lang/en/block_course_contents.php
@@ -28,8 +28,12 @@ defined('MOODLE_INTERNAL') || die();
 $string['config_blocktitle'] = 'Block title';
 $string['config_blocktitle_default'] = 'Table of contents';
 $string['config_blocktitle_help'] = 'Leave this field empty to use the default block title. If you define a title here, it will be used instead of the default one.';
+$string['config_blocktitle_default_help'] = 'You can define the default block title here.';
 $string['config_enumerate'] = 'Enumerate section titles';
 $string['config_enumerate_label'] = 'If enabled, the section number is displayed before the section title';
 $string['course_contents:addinstance'] = 'Add a new course contents block';
 $string['notusingsections'] = 'This course format does not use sections.';
 $string['pluginname'] = 'Course contents';
+
+$string['defaults_header'] = 'Default Settings';
+$string['defaults_desc'] = 'These settings will be used as defaults, but will not override the user\'s choices.';

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * course_contents global settings.
+ *
+ * @package    block_course_contents
+ * @copyright  2012 David Mudrak <david@moodle.com>
+ * @copyright  2016 COMETE (Paris Ouest University)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$settings->add(new admin_setting_heading(
+  'defaults',
+  get_string('defaults_header', 'block_course_contents'),
+  get_string('defaults_desc',   'block_course_contents')
+));
+
+$settings->add(new admin_setting_configcheckbox(
+  'course_contents/enumerate_default',
+  get_string('config_enumerate', 'block_course_contents'),
+  get_string('config_enumerate_label', 'block_course_contents'),
+  '1'
+));
+
+$settings->add(new admin_setting_configtext(
+  'course_contents/blocktitle_default',
+  get_string('config_blocktitle', 'block_course_contents'),
+  get_string('config_blocktitle_default_help', 'block_course_contents'),
+  get_string('config_blocktitle_default', 'block_course_contents')
+));


### PR DESCRIPTION
Our users wanted to remove the sections enumeration. We choose to modify the plugin and add some default settings. The plugin will perform the same:

- the defaults have been set to preserve current behavior
- if a block's settings are modified by a user, these settings will apply

The default settings are the same as the blocks ones: blocktitle and enumerate.

By the way: this plugin still works with Moodle 3.1